### PR TITLE
[Bug] Object types

### DIFF
--- a/src/Ulid/UlidType.php
+++ b/src/Ulid/UlidType.php
@@ -8,7 +8,6 @@ use Doctrine\DBAL\Platforms\AbstractPlatform;
 use Doctrine\DBAL\Types\ConversionException;
 use Doctrine\DBAL\Types\GuidType;
 use Symfony\Component\Uid\Ulid;
-use Throwable;
 
 /**
  * @author Guillaume Loulier <contact@guillaumeloulier.fr>
@@ -40,6 +39,10 @@ final class UlidType extends GuidType
     {
         if (null === $value || '' === $value) {
             return null;
+        }
+
+        if ($value instanceof Ulid) {
+            return $value;
         }
 
         if (!Ulid::isValid($value)) {

--- a/src/Uuid/UuidType.php
+++ b/src/Uuid/UuidType.php
@@ -42,6 +42,10 @@ final class UuidType extends GuidType
             return null;
         }
 
+        if ($value instanceof Uuid) {
+            return $value;
+        }
+
         if (!Uuid::isValid($value)) {
             throw ConversionException::conversionFailed($value, self::NAME);
         }

--- a/tests/Ulid/UlidTypeTest.php
+++ b/tests/Ulid/UlidTypeTest.php
@@ -102,4 +102,14 @@ final class UlidTypeTest extends TestCase
         $value = Type::getType('ulid')->convertToPHPValue(strtr($entryValue, ['-' => '0']), $platform);
         static::assertInstanceOf(Ulid::class, $value);
     }
+
+    public function testTypeCanBeConvertedToPHPValueWhenUsingAnUlidObject(): void
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+
+        $ulid = new Ulid();
+
+        $value = Type::getType('ulid')->convertToPHPValue($ulid, $platform);
+        static::assertInstanceOf(Ulid::class, $value);
+    }
 }

--- a/tests/Uuid/UuidTypeTest.php
+++ b/tests/Uuid/UuidTypeTest.php
@@ -97,4 +97,14 @@ final class UuidTypeTest extends TestCase
         $value = Type::getType('uuid')->convertToPHPValue($uuid->toRfc4122(), $platform);
         static::assertInstanceOf(Uuid::class, $value);
     }
+
+    public function testTypeCanBeConvertedToPHPValueWhenUsingAnUuidObject(): void
+    {
+        $platform = $this->createMock(AbstractPlatform::class);
+
+        $uuid = Uuid::v4();
+
+        $value = Type::getType('uuid')->convertToPHPValue($uuid, $platform);
+        static::assertInstanceOf(Uuid::class, $value);
+    }
 }


### PR DESCRIPTION
As explained here, by default, the types does not support returning an object when an object is passed, this PR solve the issue.

Close https://github.com/Guikingone/SymfonyUidDoctrine/issues/1